### PR TITLE
Gap marker on journal entries

### DIFF
--- a/src/bocken/admin/journal_entry_admin.py
+++ b/src/bocken/admin/journal_entry_admin.py
@@ -6,7 +6,7 @@ class JournalEntryAdmin(ModelAdmin):
 
     list_display = (
         'agreement', 'created', 'group',
-        'meter_start', 'meter_stop', 'get_total_distance'
+        'meter_start_gap_marker', 'meter_stop_gap_marker', 'get_total_distance'
     )
     ordering = ('-meter_stop', )
     search_fields = [

--- a/src/bocken/models/agreement.py
+++ b/src/bocken/models/agreement.py
@@ -1,10 +1,9 @@
 from django.db import models
 from bocken.validators import validate_phonenumber, validate_personnummer
-from ..utils import format_personnummer
+from ..utils import format_personnummer, mark_admin_list_cell
 from ..fields import PhonenumberField
 from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import now, timedelta
-from django.utils.html import format_html
 from django.template.defaultfilters import date
 from django.core.mail import send_mass_mail
 from django.conf import settings
@@ -95,15 +94,8 @@ class Agreement(models.Model):
         This is used in the admin pages.
         """
         if self.has_expired():
-            return format_html(
-                (
-                    '<p '
-                    'style="background: rgb(220, 38, 38);'
-                    'color: white; margin:0; padding:0;'
-                    '">{}</p>'
-                ),
-                date(self.expires),  # Format the date correctly
-            )
+            formatted_date = date(self.expires)  # Format the date correctly
+            return mark_admin_list_cell(formatted_date)
         else:
             return self.expires
     expires_colored.admin_order_field = 'expires'

--- a/src/bocken/models/journal_entry.py
+++ b/src/bocken/models/journal_entry.py
@@ -1,9 +1,9 @@
 from django.db import models
 from django.utils.formats import date_format
-from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 # Report must be imported like this to avoid circular import
 import bocken.models.report as report
+from bocken.utils import mark_admin_list_cell
 
 
 class JournalEntry(models.Model):
@@ -65,15 +65,7 @@ class JournalEntry(models.Model):
             return self.meter_start
 
         if previous_entry.meter_stop != self.meter_start:
-            return format_html(
-                (
-                    '<p '
-                    'style="background: rgb(220, 38, 38);'
-                    'color: white; margin:0; padding:0;'
-                    '">{}</p>'
-                ),
-                self.meter_start
-            )
+            return mark_admin_list_cell(self.meter_start)
         else:
             return self.meter_start
     meter_start_gap_marker.admin_order_field = 'meter_start'
@@ -88,15 +80,7 @@ class JournalEntry(models.Model):
             return self.meter_stop
 
         if previous_entry.meter_start != self.meter_stop:
-            return format_html(
-                (
-                    '<p '
-                    'style="background: rgb(220, 38, 38);'
-                    'color: white; margin:0; padding:0;'
-                    '">{}</p>'
-                ),
-                self.meter_stop
-            )
+            return mark_admin_list_cell(self.meter_stop)
         else:
             return self.meter_stop
     meter_stop_gap_marker.admin_order_field = 'meter_stop'

--- a/src/bocken/models/journal_entry.py
+++ b/src/bocken/models/journal_entry.py
@@ -57,6 +57,7 @@ class JournalEntry(models.Model):
     get_total_distance.short_description = _("Driven Distance (km)")
 
     def meter_start_gap_marker(self):
+        """Mark meter_start cells in the admin view if a gap has occured."""
         try:
             previous_entry = JournalEntry.objects.filter(
                 meter_stop__lt=self.meter_stop
@@ -72,6 +73,7 @@ class JournalEntry(models.Model):
     meter_start_gap_marker.short_description = meter_start.verbose_name
 
     def meter_stop_gap_marker(self):
+        """Mark meter_stop cells in the admin view if a gap has occured."""
         try:
             previous_entry = JournalEntry.objects.filter(
                 meter_stop__gt=self.meter_stop

--- a/src/bocken/utils.py
+++ b/src/bocken/utils.py
@@ -1,5 +1,6 @@
 from personnummer import personnummer as pn
 from math import ceil
+from django.utils.html import format_html
 
 
 def personnummer_is_t_number(personnummer):
@@ -37,3 +38,20 @@ def kilometers_to_mil(kilometers: int):
     The result is rounded up since groups pay for every started mil.
     """
     return ceil(kilometers / 10)
+
+
+def mark_admin_list_cell(value):
+    """
+    Mark a list cell in the admin pages by making the cell red.
+
+    Returns the formatted list cell with the value provided
+    """
+    return format_html(
+        (
+            '<p '
+            'style="background: rgb(220, 38, 38);'
+            'color: white; margin:0; padding:0;'
+            '">{}</p>'
+        ),
+        value,  # Format the date correctly
+    )


### PR DESCRIPTION
If a gap has occured between to journal entries they are now marked in red so it's clear where the gap has occured, making it easier to identify and to solve the gap.
![image](https://user-images.githubusercontent.com/19433606/152167154-03541ffa-8c6d-4abe-ba46-2ac7781fb77b.png)

Closes #163 