### PR TITLE
Change django to 3.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django[argon2]==3.2.9
+Django[argon2]==3.2.11
 
 # Postgres
 psycopg2==2.9.3


### PR DESCRIPTION
While we wait for upgrading to django 4 we can update to 3.2.11 that fixes some securities